### PR TITLE
Add history keys in college collection schema

### DIFF
--- a/fields/academia.js
+++ b/fields/academia.js
@@ -1,10 +1,29 @@
 module.exports = Object.freeze({
   TS_UPDATED_AT: 'updatedAt',
   TS_CREATED_AT: 'createdAt',
-  COLLEGE: 'college',
-  COURSE: 'course',
-  BRANCH: 'branch',
-  SEMESTER: 'semester',
-  SUBJECT: 'subject',
   TS_LAST_LIST_MODIFICATION: 'lastListModification',
+
+  COLLEGE: 'college',
+  COLLEGE_NAME_HISTORY: 'collegeNameHistory',
+  COLLEGE_ID: '_id',
+
+  COURSE: 'course',
+  COURSES: 'courses',
+  COURSE_NAME_HISTORY: 'courseNameHistory',
+  COURSE_ID: 'courseId',
+
+  BRANCH: 'branch',
+  BRANCHES: 'branches',
+  BRANCH_NAME_HISTORY: 'branchNameHistory',
+  BRANCH_ID: 'branchId',
+
+  SEMESTER: 'semester',
+  SEMESTERS: 'semesters',
+  SEMESTER_NAME_HISTORY: 'semesterNameHistory',
+  SEMESTER_ID: 'semesterId',
+
+  SUBJECT: 'subject',
+  SUBJECTS: 'subjects',
+  SUBJECT_NAME_HISTORY: 'subjectNameHistory',
+  SUBJECT_ID: 'subjectId',
 });

--- a/models/academia/branch.js
+++ b/models/academia/branch.js
@@ -11,6 +11,7 @@ const branchSchema = new Schema({
     trim: true,
     minlength: 1,
   },
+  branchNameHistory: [String],
   abbreviation: {
     type: String,
     trim: true,

--- a/models/academia/college.js
+++ b/models/academia/college.js
@@ -14,6 +14,7 @@ const collegeSchema = new Schema({
     unique: true,
     index: true,
   },
+  collegeNameHistory: [String],
   abbreviation: {
     type: String,
     trim: true,

--- a/models/academia/course.js
+++ b/models/academia/course.js
@@ -13,6 +13,7 @@ const courseSchema = new Schema({
     trim: true,
     minlength: 1,
   },
+  courseNameHistory: [String],
   branches: [branchSchema],
   gpaMetric: {
     type: String,

--- a/models/academia/semester.js
+++ b/models/academia/semester.js
@@ -10,6 +10,7 @@ const semesterSchema = new Schema({
     type: String,
     required: true,
   },
+  semesterNameHistory: [String],
   creditsTotal: {
     type: Number,
   },

--- a/models/academia/subject.js
+++ b/models/academia/subject.js
@@ -11,6 +11,7 @@ const subjectSchema = new Schema({
     trim: true,
     minlength: 1,
   },
+  subjectNameHistory: [String],
   subjectCode: {
     type: String,
     trim: true,


### PR DESCRIPTION
This PR adds history keys in schema of `colleges` collection in the database.
Following history keys are added in the collection schema:
- `college_name_history`
- `course_name_history`
- `branch_name_history`
- `semester_name_history`
- `subject_name_history`

related #10 