### PR TITLE
Add api to delete user data

### DIFF
--- a/CustomError.js
+++ b/CustomError.js
@@ -1,26 +1,14 @@
+const {getReasonPhrase} = require('http-status-codes');
+
+// eslint-disable-next-line require-jsdoc
 class CustomError extends Error {
-  static get NAME_AUTHENTICATION_ERROR() {
-    return 'AuthenticationError';
-  }
-  static get NAME_AUTHORIZATION_ERROR() {
-    return 'AuthorizationError';
-  }
-  static get NAME_VALUE_ERROR() {
-    return 'ValueError';
-  }
+  // eslint-disable-next-line require-jsdoc
   constructor(message, statusCode) {
     super(message);
     this.name = this.constructor.name;
     this.statusCode = statusCode;
-
-    if (this.statusCode === 401) {
-      this.name = this.constructor.NAME_AUTHENTICATION_ERROR;
-    }
-    if (this.statusCode === 403) {
-      this.name = this.constructor.NAME_AUTHORIZATION_ERROR;
-    }
-    if (this.statusCode === 400) {
-      this.name = this.constructor.NAME_VALUE_ERROR;
+    if (getReasonPhrase(statusCode)) {
+      this.name = getReasonPhrase(statusCode);
     }
 
     if (Error.captureStackTrace) {

--- a/fields/user.js
+++ b/fields/user.js
@@ -2,6 +2,7 @@ const ROOT = require(__dirname + '/../config').ROOT;
 const academiaFields = require(ROOT + '/fields/academia');
 
 module.exports = Object.freeze({
+  EMAIL: 'email',
   COLLEGE_ID: academiaFields.COLLEGE_ID,
   COURSE_ID: academiaFields.COURSE_ID,
   BRANCH_ID: academiaFields.BRANCH_ID,

--- a/middlewares/authenticateUser.js
+++ b/middlewares/authenticateUser.js
@@ -1,8 +1,7 @@
+const {StatusCodes, ReasonPhrases} = require('http-status-codes');
 const ROOT = require(__dirname + '/../config').ROOT;
 const authenticateClientId = require(ROOT +
   '/utility/oauth/authenticateClientId');
-const CustomError = require(ROOT + '/CustomError');
-
 /**
  *
  * @param {RequestObject} req
@@ -23,8 +22,8 @@ function authenticateUser(req, res, next) {
         next();
       })
       .catch((err) => {
-        err.statusCode = 401;
-        err.name = CustomError.NAME_AUTHENTICATION_ERROR;
+        err.statusCode = StatusCodes.UNAUTHORIZED;
+        err.name = ReasonPhrases.UNAUTHORIZED;
         next(err);
       });
 }

--- a/routes/user/gpa.js
+++ b/routes/user/gpa.js
@@ -6,9 +6,10 @@ const authenticateUser = require(ROOT + '/middlewares/authenticateUser');
 const {User} = require(ROOT + '/models/user');
 const utility = require(ROOT + '/utility');
 const userServices = require(ROOT + '/services/user');
+const userFields = require(ROOT + '/fields/user');
+const CustomError = require(ROOT + '/CustomError');
 // eslint-disable-next-line new-cap
 const router = express.Router();
-
 router.get('/gpa-data', authenticateUser, (req, res, next) => {
   User.findOne({email: req.user.email})
       .select('-_id -__v')
@@ -50,4 +51,22 @@ router.post('/gpa-data', authenticateUser, (req, res, next) => {
       .catch(next);
 });
 
+router.delete('/gpa-data', authenticateUser, (req, res, next) => {
+  User.deleteOne({
+    [userFields.EMAIL]: req.user.email,
+  })
+      .then((queryRes) => {
+        if (queryRes.deletedCount) {
+          res
+              .status(StatusCodes.OK)
+              .json(utility.responseUtil.getSuccessResponse());
+        } else {
+          throw new CustomError(
+              'Nothing to delete, user data do not exist',
+              StatusCodes.NOT_FOUND,
+          );
+        }
+      })
+      .catch(next);
+});
 module.exports = router;


### PR DESCRIPTION
This PR adds API to delete user data from the database.
API description:

```
DELETE /user/gpa-data
```
Response on successfully deleting user data:

```
{
  success: true
}
```

If user data is not found then API will return with `404` HTTP error code with response body:
```
{
  type: NOT_FOUND,
  message: "Nothing to delete, user data not found"
}
```

User token should be passed in `Authorization` header

Closes #8 